### PR TITLE
Removes viper constraint

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,7 +44,3 @@
 [prune]
   go-tests = true
   unused-packages = true
-
-[[constraint]]
-  name = "github.com/spf13/viper"
-  version = "1.0.0"


### PR DESCRIPTION
## Why is this change necessary?
It's not being used and it causes a warning on `dep ensure`

```
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/spf13/viper

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies,
```
## How does it address the issue?
Just removes dependency
## What side effects does this change have?
Warning is gone after that.





