### PR TITLE
feat: add zsh completion command

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation; either version 2.1 of the License, or (at your option)
+// any later version.
+//
+// This library is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+// details.
+
+package cmd
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}
+
+var completionCmd = &cobra.Command{
+	Use:   "completion",
+	Short: "Generate ZSH completion script",
+	Long: `Generate a ZSH completion script for lpn.
+
+To load completions in your current shell session:
+
+	source <(lpn completion)
+
+To load completions for every new session, execute once:
+
+	lpn completion > "${fpath[1]}/_lpn"
+
+You will need to start a new shell for this setup to take effect.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := rootCmd.GenZshCompletion(os.Stdout)
+		if err != nil {
+			slog.Error("Error generating ZSH completion", "error", err)
+		}
+	},
+}

--- a/e2e/completion_test.go
+++ b/e2e/completion_test.go
@@ -1,0 +1,31 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ActiveState/termtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletion(t *testing.T) {
+	lpnPath := getLpnPath(t)
+
+	opts := termtest.Options{
+		CmdName:       lpnPath,
+		Args:          []string{"completion"},
+		RetainWorkDir: false,
+	}
+
+	tt, err := termtest.New(opts)
+	require.NoError(t, err)
+	defer tt.Close()
+
+	// Expect ZSH completion output
+	_, err = tt.Expect("#compdef", 5*time.Second)
+	require.NoError(t, err)
+
+	// Verify exit code
+	_, err = tt.ExpectExitCode(0, 5*time.Second)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Closes #69

## Summary

- Added `lpn completion` command that generates ZSH shell completion scripts using cobra's built-in `GenZshCompletion`
- Includes usage instructions for loading completions in current session or permanently
- Added e2e test verifying the completion command outputs valid ZSH completion (`#compdef`) and exits cleanly

## Status

✅ **SHIP** — Iteration 1

## Work Summary

New `cmd/completion.go` registers a `completion` subcommand on the root cobra command. When invoked, it writes ZSH completion output to stdout via `rootCmd.GenZshCompletion(os.Stdout)`. The command's long description documents how to source completions interactively or install them permanently. An e2e test (`e2e/completion_test.go`) follows the existing test patterns (termtest + require) and asserts the output contains `#compdef` and exits with code 0.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_