### PR TITLE
fix: address multiple container lookup and deploy exit code issues

### DIFF
--- a/cmd/checkContainer.go
+++ b/cmd/checkContainer.go
@@ -55,7 +55,7 @@ var checkContainerCECmd = &cobra.Command{
 	Use:   "ce",
 	Short: "Checks if there is a CE container created by lpn",
 	Long: `Checks if there is a CE container created by lpn (Liferay Portal Nook).
-	Uses docker container inspect to check if there is a CE container with name [lpn-release] created by lpn (Liferay Portal Nook)`,
+	Uses docker container inspect to check if there is a CE container with name [lpn-ce] created by lpn (Liferay Portal Nook)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ce := liferay.CE{}
 
@@ -79,7 +79,7 @@ var checkContainerDXPCmd = &cobra.Command{
 	Use:   "dxp",
 	Short: "Checks if there is a DXP container created by lpn",
 	Long: `Checks if there is a DXP container created by lpn (Liferay Portal Nook).
-	Uses docker container inspect to check if there is a DXP container with name [lpn-release] created by lpn (Liferay Portal Nook)`,
+	Uses docker container inspect to check if there is a DXP container with name [lpn-dxp] created by lpn (Liferay Portal Nook)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		dxp := liferay.DXP{}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -222,13 +222,19 @@ func deployPaths(image liferay.Image, paths []string) {
 
 	// Collect results from workers
 
+	failed := false
 	for i := 0; i < len(paths); i++ {
 		select {
 		case <-resultChannel:
 			slog.Info("File deployed successfully to deploy dir", "file", paths[i], "deployDir", image.GetDeployFolder())
 		case err := <-errorChannel:
-			slog.Warn("Impossible to deploy the file to the container", "file", paths[i], "error", err)
+			slog.Error("Impossible to deploy the file to the container", "file", paths[i], "error", err)
+			failed = true
 		}
+	}
+
+	if failed {
+		os.Exit(1)
 	}
 }
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -184,8 +184,9 @@ var pullRelease = &cobra.Command{
 // pullDockerImage uses the image interface to pull it from Docker Hub, removing the cached on if
 func pullDockerImage(image liferay.Image, forceRemoval bool) {
 	if forceRemoval {
-		err := docker.RemoveDockerImage(image.GetFullyQualifiedName())
-		if err != nil {
+		if docker.CheckDockerImageExists(image.GetFullyQualifiedName()) {
+			docker.RemoveDockerImage(image.GetFullyQualifiedName())
+		} else {
 			slog.Info("The image was not found in the local cache. Skipping removal", "image", image.GetFullyQualifiedName())
 		}
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -376,7 +376,7 @@ func RemoveDockerContainer(image liferay.Image) error {
 	if len(containers) == 0 {
 		err = errors.New("Error response from daemon: No such container: " + image.GetContainerName())
 
-		slog.Error("Could not filter container by label", "container", image.GetContainerName(), "label", label, "error", err)
+		slog.Debug("No containers found for label", "container", image.GetContainerName(), "label", label)
 
 		return err
 	}
@@ -590,7 +590,8 @@ func RunLiferayDockerImage(
 			Env:          environmentVariables,
 			ExposedPorts: exposedPorts,
 			Labels: map[string]string{
-				"lpn-type": image.GetType(),
+				"lpn-type":           image.GetType(),
+				"lpn-container-name": image.GetContainerName(),
 			},
 		},
 		&containertypes.HostConfig{


### PR DESCRIPTION
Closes #113

## Status
**SHIP** — Iteration 1

## Summary
- **FAIL 1 & 2 (Critical):** Added missing `lpn-container-name` label to Liferay containers in `RunLiferayDockerImage`, fixing `checkc` and `deploy` container lookups
- **FAIL 3 (Critical):** Deploy now tracks failures and calls `os.Exit(1)` instead of silently exiting 0
- **NOTE 4:** Force-pull now checks image existence before attempting removal, eliminating confusing WARN message
- **NOTE 5:** Prune log level downgraded from ERROR to DEBUG for the normal empty-container case
- **DOC BUG 6:** Corrected CE and DXP help text from `[lpn-release]` to `[lpn-ce]` and `[lpn-dxp]`

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_