### PR TITLE
feat: deprecate release subcommands in favour of ce and dxp

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,13 @@ Once you have typed the proper command, to specify with which image type you wan
 
   - ce
   - dxp
-  - release
   - nightly
   - commerce
+  - release (**deprecated**)
 
 So any command needs the combination of one of the subcommands above. So to run a DXP image, you would need to execute `lpn run dxp`.
+
+> **Deprecation notice:** the `release` subcommands are deprecated in favour of the official `ce` and `dxp` subcommands. They still work for now, but running them prints a deprecation warning and they will be removed in a future release. Please migrate to `ce` or `dxp`.
 
 ## Running a container from a Liferay Portal/DXP image
 

--- a/cmd/checkContainer.go
+++ b/cmd/checkContainer.go
@@ -100,8 +100,9 @@ var checkContainerNightlyCmd = &cobra.Command{
 }
 
 var checkContainerReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Checks if there is a Release container created by lpn",
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Checks if there is a Release container created by lpn",
 	Long: `Checks if there is a Release container created by lpn (Liferay Portal Nook).
 	Uses docker container inspect to check if there is a Release container with name [lpn-release] created by lpn (Liferay Portal Nook)`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/checkImage.go
+++ b/cmd/checkImage.go
@@ -167,8 +167,9 @@ var checkImageNightly = &cobra.Command{
 }
 
 var checkImageRelease = &cobra.Command{
-	Use:   "release",
-	Short: "Checks if the proper Liferay Portal release image has been pulled by lpn",
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Checks if the proper Liferay Portal release image has been pulled by lpn",
 	Long: `Checks if the proper Liferay Portal release image has been pulled by lpn.
 	Uses docker image inspect to check if the proper Liferay Portal image has 
 	been pulled by lpn (Liferay Portal Nook). If no image tag is passed to the command,

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -128,8 +128,9 @@ var deployNightly = &cobra.Command{
 }
 
 var deployRelease = &cobra.Command{
-	Use:   "release",
-	Short: "Deploys files or a directory to Liferay Portal's deploy folder in the container run by lpn",
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Deploys files or a directory to Liferay Portal's deploy folder in the container run by lpn",
 	Long: `Deploys files or a directory to Liferay Portal's deploy folder in the container run by lpn.
 	The appropriate tag is calculated from the image the container was build from.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -92,9 +92,10 @@ var logNightlyCmd = &cobra.Command{
 }
 
 var logReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Displays logs for the Liferay Portal Release instance",
-	Long:  `Displays logs for the Liferay Portal Release instance, identified by [lpn-release].`,
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Displays logs for the Liferay Portal Release instance",
+	Long:       `Displays logs for the Liferay Portal Release instance, identified by [lpn-release].`,
 	Run: func(cmd *cobra.Command, args []string) {
 		release := liferay.Release{}
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -98,9 +98,10 @@ var openNightlyCmd = &cobra.Command{
 }
 
 var openReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Opens a browser with the Liferay Portal Release instance",
-	Long:  `Opens a browser with  the Liferay Portal Release instance, identified by [lpn-release].`,
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Opens a browser with the Liferay Portal Release instance",
+	Long:       `Opens a browser with  the Liferay Portal Release instance, identified by [lpn-release].`,
 	Run: func(cmd *cobra.Command, args []string) {
 		release := liferay.Release{}
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -50,7 +50,7 @@ var pullCmd = &cobra.Command{
 	Short: "Pulls a Liferay Portal Docker image",
 	Long: `Pulls a Liferay Portal Docker image from one of the Official repositories (see configuration file).
 		For non-official Docker images, the tool pulls from the official repositories (see configuration file)
-	For that, please run this command adding "ce", "commerce", "dxp", "release" or "nightly" subcommands.`,
+	For that, please run this command adding "ce", "commerce", "dxp" or "nightly" subcommands.`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 1 {
 			return errors.New("pull requires zero or one argument representing the image tag to be pulled")
@@ -159,8 +159,9 @@ var pullNightly = &cobra.Command{
 }
 
 var pullRelease = &cobra.Command{
-	Use:   "release",
-	Short: "Pulls a Liferay Portal Docker image from releases",
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Pulls a Liferay Portal Docker image from releases",
 	Long: `Pulls a Liferay Portal instance, obtained from the unofficial releases repository.
 	If no image tag is passed to the command, the "latest" tag will be used.`,
 	Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -93,9 +93,10 @@ var rmNightlyCmd = &cobra.Command{
 }
 
 var rmReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Removes the Liferay Portal Release instance",
-	Long:  `Removes the Liferay Portal Release instance, identified by [lpn-release].`,
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Removes the Liferay Portal Release instance",
+	Long:       `Removes the Liferay Portal Release instance, identified by [lpn-release].`,
 	Run: func(cmd *cobra.Command, args []string) {
 		release := liferay.Release{}
 

--- a/cmd/rmi.go
+++ b/cmd/rmi.go
@@ -113,9 +113,10 @@ var rmiNightlyCmd = &cobra.Command{
 }
 
 var rmiReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Removes the Liferay Portal Release image",
-	Long:  `Removes the Liferay Portal Release image from the Docker host.`,
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Removes the Liferay Portal Release image",
+	Long:       `Removes the Liferay Portal Release image from the Docker host.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if tagToRemove == "" {
 			tagToRemove = "latest"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,10 +54,16 @@ func Execute() {
 	}
 }
 
+// releaseDeprecationMessage is appended to the deprecation warning printed by
+// Cobra whenever one of the "release" subcommands is used. The unofficial
+// "release" images are being retired in favour of the official "ce" and "dxp"
+// images.
+const releaseDeprecationMessage = `use the "ce" or "dxp" subcommands instead, as the "release" images are deprecated`
+
 // SubCommandInfo Shows a message for subcommands
 func SubCommandInfo() {
 	// delegate to subcommands
 	slog.Warn(
-		"Please run this command adding 'ce', 'commerce', 'dxp', 'nightly' or 'release' " +
+		"Please run this command adding 'ce', 'commerce', 'dxp' or 'nightly' " +
 			"subcommands.")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -61,7 +61,7 @@ var runCmd = &cobra.Command{
 	Short: "Runs a Liferay Portal instance",
 	Long: `Runs a Liferay Portal instance, obtained from the Official repositories (see configuration file).
 		For non-official Docker images, the tool runs images obtained from the unofficial repositories (see configuration file).
-	For that, please run this command adding "ce", "commerce", "dxp", "release" or "nightly" subcommands.`,
+	For that, please run this command adding "ce", "commerce", "dxp" or "nightly" subcommands.`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 1 {
 			return errors.New("run requires zero or one argument representing the image tag to be run")
@@ -172,8 +172,9 @@ var runNightlyCmd = &cobra.Command{
 }
 
 var runReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Runs a Liferay Portal instance from releases",
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Runs a Liferay Portal instance from releases",
 	Long: `Runs a Liferay Portal instance, obtained from the unofficial releases repository.
 	If no image tag is passed to the command, the "latest" tag will be used.`,
 	Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -94,9 +94,10 @@ var startNightlyCmd = &cobra.Command{
 }
 
 var startReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Starts the Liferay Portal Release instance",
-	Long:  `Starts the Liferay Portal Release instance, identified by [lpn-release].`,
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Starts the Liferay Portal Release instance",
+	Long:       `Starts the Liferay Portal Release instance, identified by [lpn-release].`,
 	Run: func(cmd *cobra.Command, args []string) {
 		release := liferay.Release{}
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -94,9 +94,10 @@ var stopNightlyCmd = &cobra.Command{
 }
 
 var stopReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Stops the Liferay Portal Release instance",
-	Long:  `Stops the Liferay Portal Release instance, identified by [lpn-release].`,
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Stops the Liferay Portal Release instance",
+	Long:       `Stops the Liferay Portal Release instance, identified by [lpn-release].`,
 	Run: func(cmd *cobra.Command, args []string) {
 		release := liferay.Release{}
 

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -84,7 +84,7 @@ var tagsCmd = &cobra.Command{
 	Short: "Lists all tags for Liferay Portal Docker image",
 	Long: `Lists all tags for Liferay Portal Docker image from the Official repositories (see configuration file).
 		For non-official Docker images, the tool lists tags from the unofficial repositories (see configuration file).
-	For that, please run this command adding "commerce", "release" or "nightly" subcommands.`,
+	For that, please run this command adding "commerce" or "nightly" subcommands.`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 1 {
 			return errors.New("tags requires zero or one argument representing the image tag to be pulled")
@@ -145,9 +145,10 @@ var tagsNightlyCmd = &cobra.Command{
 }
 
 var tagsReleaseCmd = &cobra.Command{
-	Use:   "release",
-	Short: "Lists all tags for Liferay Portal Release Docker image",
-	Long:  `Lists all tags for Liferay Portal Release Docker image from one of the unofficial repository`,
+	Use:        "release",
+	Deprecated: releaseDeprecationMessage,
+	Short:      "Lists all tags for Liferay Portal Release Docker image",
+	Long:       `Lists all tags for Liferay Portal Release Docker image from one of the unofficial repository`,
 	Run: func(cmd *cobra.Command, args []string) {
 		release := liferay.Release{}
 


### PR DESCRIPTION
Closes #60

**Status:** ✅ Ready for review (SHIP after 1 iteration)

## Summary

Deprecates the `release` subcommands in favour of the official `ce` and `dxp` subcommands, using Cobra's built-in `Deprecated` field so the commands keep working while steering users toward the supported alternatives.

- Added a shared `releaseDeprecationMessage` constant in `cmd/root.go` and applied `Deprecated: releaseDeprecationMessage` to all 12 `release` subcommands (`run`, `pull`, `checkImage`, `start`, `stop`, `open`, `log`, `tags`, `deploy`, `rm`, `rmi`, `checkContainer`).
- Invoking a `release` subcommand now prints a deprecation warning and hides it from `--help` listings, while remaining fully functional.
- Removed `release` from parent commands' help/long text and the `SubCommandInfo` warning so it is no longer advertised as a recommended subcommand.
- Updated `README.md` with a deprecation notice and marked `release` as deprecated in the canonical subcommand list.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- `gofmt -l cmd/` clean ✅
- Smoke test: `lpn run --help` no longer lists `release`; `lpn run release --help` prints the deprecation warning.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_